### PR TITLE
stagefright: Add support for VT limits

### DIFF
--- a/media/libstagefright/MediaCodecList.cpp
+++ b/media/libstagefright/MediaCodecList.cpp
@@ -969,7 +969,13 @@ status_t MediaCodecList::addLimit(const char **attrs) {
     // complexity: range + default
     bool found;
 
-    if (name == "aspect-ratio" || name == "bitrate" || name == "block-count"
+    // VT specific limits
+    if (name.find("vt-") == 0) {
+        AString value;
+        if (msg->findString("value", &value) && value.size()) {
+            mCurrentInfo->addDetail(name, value);
+        }
+    } else if (name == "aspect-ratio" || name == "bitrate" || name == "block-count"
             || name == "blocks-per-second" || name == "complexity"
             || name == "frame-rate" || name == "quality" || name == "size"
             || name == "measured-blocks-per-second" || name.startsWith("measured-frame-rate-")) {


### PR DESCRIPTION
tone devices have VT limits inside their media configuration.

If VT limits types aren't properly parsed, codecs are stopped from loading.